### PR TITLE
Thumbnail management

### DIFF
--- a/georeference/components/src/InfoPanel.svelte
+++ b/georeference/components/src/InfoPanel.svelte
@@ -161,9 +161,7 @@ function setSplit(operation) {
               <div>
                 {child.title}
               </div>
-              <div style="text-align:center;">
-                <img src={child.urls.thumbnail} alt={child.title} title={child.title}>
-              </div>
+              <img src={child.urls.thumbnail} alt={child.title} title={child.title}>
               <div>
                 <ul>
                   <li><strong>Status:</strong> {child.status}</li>
@@ -391,8 +389,8 @@ tr:nth-child(odd) {
 
 .document-item img {
   margin: 15px;
-  max-height: 115px;
-  width: auto;
+  max-height: 200px;
+  max-width: 200px;
 }
 
 .document-item div:first-child {

--- a/loc_insurancemaps/management/commands/oneoffs.py
+++ b/loc_insurancemaps/management/commands/oneoffs.py
@@ -1,0 +1,56 @@
+from django.core.management.base import BaseCommand, CommandError
+
+from geonode.documents.models import Document
+from loc_insurancemaps.models import FullThumbnail, Volume
+
+class Command(BaseCommand):
+    help = 'command to search the Library of Congress API.'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "operation",
+            choices=[
+                "fix-fullthumbnails",
+                "fix-defaultthumbnails",
+            ],
+            help="the identifier of the LoC resource to add",
+        )
+
+    def handle(self, *args, **options):
+
+        if options['operation'] == "fix-fullthumbnails":
+            docs = Document.objects.all()
+            print(f"{docs.count()} documents")
+            ext = 0
+            new = 0
+            for d in docs:
+                if "missing" in d.thumbnail_url:
+                   print(d)
+                try:
+                    thumb = FullThumbnail.objects.get(document=d)
+                    thumb.save()
+                    ext += 1
+                except FullThumbnail.DoesNotExist:
+                    thumb = FullThumbnail(document=d)
+                    thumb.save()
+                    new += 1
+                #d.thumbnail_url = thumb.image.url
+                #d.save(update_fields=["thumbnail_url"])
+            print(f"{ext} existing FullThumbnails")
+            print(f"{new} new FullThumbnails created")
+
+            print("updating all volume lookups...")
+            for v in Volume.objects.all():
+                v.populate_lookups()
+            print("complete.")
+
+        if options['operation'] == "fix-defaultthumbnails":
+            docs = Document.objects.all()
+            print(f"{docs.count()} documents")
+            mis = 0
+            for d in docs:
+                if "missing" in d.thumbnail_url:
+                   mis += 1
+                   d.save()
+            print(f"{mis} missing thumbnail(s) created")
+

--- a/loc_insurancemaps/templates/base/_resourcebase_snippet.html
+++ b/loc_insurancemaps/templates/base/_resourcebase_snippet.html
@@ -24,9 +24,9 @@
             <a href="{{ item.detail_url }}">{{ item.title }}</a>
           </h4>
         </div>
-        <div class="col-xs-3 col-lg-4 item-thumb" style="text-align:center">
+        <div class="col-xs-3 col-lg-4 item-thumb">
           <a href="{{ item.detail_url }}">
-            <img style="max-height:115px; width:auto;" ng-src="{{ item.thumbnail_url }}" />
+            <img ng-src="{{ item.thumbnail_url }}" />
           </a>
         </div>
         <div class="col-xs-9 col-lg-8 item-details">


### PR DESCRIPTION
reverts some of the changes made to improve FullThumbnail creation. Specifically, where I thought that FullThumbnail urls could easily be swapped in during document save operations to use them instead of default thumbnails, turns out this is not so easy. So, this PR does the following:

1. Reimplement the default GeoNode thumbnail creation for Documents via post_save signal (this had been disconnected).
2. Only use FullThumbnails urls when saving serialized documents to Volume lookups, i.e. they will go back to only appearing where a volume has been serialized (i.e. volume summary) and not in any default GeoNode pages (like document search) or georeference app pages (like the Georeference tab of the document detail page).
3. adds a couple of oneoff management commands for refreshing/fixing thumbnails across the system.