### PR TITLE
add simple endpoints for acquiring all tifs/jpgs/points (for MRM)

### DIFF
--- a/georeference/models.py
+++ b/georeference/models.py
@@ -176,6 +176,17 @@ class GCPGroup(models.Model):
             })
         return geo_json
 
+    def as_points_file(self):
+
+        content = "mapX,mapY,pixelX,pixelY,enable\n"
+        for gcp in self.gcps:
+            geom = gcp.geom.clone()
+            geom.transform(self.crs_epsg)
+            # pixel_y must be inverted b/c qgis puts origin at top left corner
+            content += f"{geom.x},{geom.y},{gcp.pixel_x},-{gcp.pixel_y},1\n"
+
+        return content
+
     def save_from_geojson(self, geojson, document, transformation=None):
 
         group, group_created = GCPGroup.objects.get_or_create(document=document)

--- a/loc_insurancemaps/urls.py
+++ b/loc_insurancemaps/urls.py
@@ -6,12 +6,21 @@ from django.views.generic import TemplateView, RedirectView
 from geonode.urls import urlpatterns
 from geonode.monitoring import register_url_event
 
-from .views import SimpleAPI, VolumeDetail, HomePage, Volumes
+from .views import (
+    SimpleAPI,
+    VolumeDetail,
+    HomePage,
+    Volumes,
+    MRMEndpointList,
+    MRMEndpointLayer,
+)
 
 urlpatterns += [
     path('loc/volumes/', Volumes.as_view(), name='volumes_list'),
     path('loc/api/', SimpleAPI.as_view() , name='lc_api'),
     path('loc/<str:volumeid>/', VolumeDetail.as_view(), name="volume_summary"),
+    path('mrm/', MRMEndpointList.as_view(), name="mrm_layer_list"),
+    path('mrm/<str:layerid>/', MRMEndpointLayer.as_view(), name="mrm_get_resource"),
 ]
 
 if 'georeference' in settings.INSTALLED_APPS:


### PR DESCRIPTION
Adds a very basic endpoint to support the transfer of all layer resources, 1) the geotiff, 2) the original jpg files, and 3) a QGIS-formatted .points file of the ground control points.

In the future, this will hopefully be supplanted by a full STAC endpoint, but for now it will suffice.