### PR TITLE
Add newsletter 42

### DIFF
--- a/loc_insurancemaps/components/rollup.config.js
+++ b/loc_insurancemaps/components/rollup.config.js
@@ -91,6 +91,7 @@ let exportable = [];
   "Index",
   "Navbar",
   "Footer",
+  "Participants",
 ].forEach((d) => exportable.push(componentExportDetails(d)));
 
 export default exportable;

--- a/loc_insurancemaps/components/src/Footer.svelte
+++ b/loc_insurancemaps/components/src/Footer.svelte
@@ -38,6 +38,7 @@ export let USER;
 		color: white;
 		padding: 20px;
 		font-weight: 500;
+		min-height: 190px;
 	}
 	.main-row {
 		display: flex;

--- a/loc_insurancemaps/components/src/Index.svelte
+++ b/loc_insurancemaps/components/src/Index.svelte
@@ -10,7 +10,7 @@ let showBRMap = !IS_MOBILE;
 $: showBRMapBtnLabel = showBRMap ? "Hide example viewer (Baton Rouge)" : "Show example viewer (Baton Rouge)";
 </script>
 
-<main class="banner">
+<main>
 	<div class="hero-banner">
 		<div class="">
 			<h1>Louisiana Sanborn Maps</h1>
@@ -22,13 +22,13 @@ $: showBRMapBtnLabel = showBRMap ? "Hide example viewer (Baton Rouge)" : "Show e
 		<div class="link-panel">
 			<p>Jump to some popular places</p>
 			<ul>
-				<li><a href="/viewer/new-orleans-la">New Orleans (1885-1893) &rarr;</a></li>
-				<li><a href="/viewer/baton-rouge-la">Baton Rouge (1885, 1891, 1898, 1903, 1908) &rarr;</a></li>
-				<li><a href="/viewer/alexandria-la">Alexandria (1885, 1892, 1896, 1900, 1904, 1909) &rarr;</a></li>
-				<li><a href="/viewer/plaquemine-la">Plaquemine (1885, 1891, 1896, 1900, 1906) &rarr;</a></li>
+				<li><a href="/viewer/new-orleans-la?utm_source=index-top">New Orleans (1885-1893) &rarr;</a></li>
+				<li><a href="/viewer/baton-rouge-la?utm_source=index-top">Baton Rouge (1885, 1891, 1898, 1903, 1908) &rarr;</a></li>
+				<li><a href="/viewer/alexandria-la?utm_source=index-top">Alexandria (1885, 1892, 1896, 1900, 1904, 1909) &rarr;</a></li>
+				<li><a href="/viewer/plaquemine-la?utm_source=index-top">Plaquemine (1885, 1891, 1896, 1900, 1906) &rarr;</a></li>
 			</ul>
 			<p>or search through <a href="/browse">all volumes</a>.</p>
-			<p>Currently, this site includes maps for about 140 different towns and cities across Louisiana. Want to get your hometown added? Check out our <a href="https://about.oldinsurancemaps.net/faq">FAQ page</a>.</p>
+			<p>Currently, this site includes maps for about 140 different towns and cities across Louisiana. Want to get your hometown added? Check out our <a href="https://about.oldinsurancemaps.net/faq?utm_source=index">FAQ page</a>.</p>
 			<p><em>Thank you so much to everyone who helped with this project, I've tried to make this site into a nice way to show your work!.</em></p>
 		</div>
 	</div>
@@ -44,43 +44,43 @@ $: showBRMapBtnLabel = showBRMap ? "Hide example viewer (Baton Rouge)" : "Show e
 			<div>
 				<div><i class="i-volume i-volume-lg"></i></div>
 				<p>
-					Editions or volumes of Sanborn maps are available through the <a href="https://loc.gov/collections/sanborn-maps">Library of Congress</a> and are pulled into this site through their <a href="https://www.loc.gov/apis/json-and-yaml/requests/">JSON API</a>, generating a "Volume Summary" page here (see <a href="/loc/sanborn03275_001/">Baton Rouge, 1885</a>).
+					Editions or volumes of Sanborn maps are available through the <a href="https://loc.gov/collections/sanborn-maps">Library of Congress</a> and are pulled into this site through their <a href="https://www.loc.gov/apis/json-and-yaml/requests/">JSON API</a>, generating a "Volume Summary" page here (see <a href="/loc/sanborn03275_001/?utm_source=index">Baton Rouge, 1885</a>).
 				</p>
 			</div>
 			<div>
 				<div><i class="i-document i-document-lg"></i></div>
 				<p>
-					Crowdsourcing participants <a href="/split/244/">prepare each sheet</a> in the volume individually, sometimes splitting a sheet into multiple documents, each of which must be georeferenced individually (see <a href="/resource/244">Baton Rouge, 1885, page 1</a>).
+					Crowdsourcing participants <a href="/split/244/">prepare each sheet</a> in the volume individually, sometimes splitting a sheet into multiple documents, each of which must be georeferenced individually (see <a href="/resource/244?utm_source=index">Baton Rouge, 1885, page 1</a>).
 				</p>
 			</div>
 			<div>
 				<div><i class="i-layer i-layer-lg"></i></div>
 				<p>
-					Participants georeference each document by <a href="/georeference/387">creating ground control points</a>, linking features on the old map with latitude/longitude coordinates and embedding this geographic information, creating a geospatial layer (see <a href="/resource/389">Baton Rouge, 1885, page 1, part 3</a>).
+					Participants georeference each document by <a href="/georeference/387?utm_source=index">creating ground control points</a>, linking features on the old map with latitude/longitude coordinates and embedding this geographic information, creating a geospatial layer (see <a href="/resource/389?utm_source=index">Baton Rouge, 1885, page 1, part 3</a>).
 				</p>
 			</div>
 			<div>
 				<div><i class="i-webmap i-webmap-lg"></i></div>
 				<p>
-					As they are georeferenced, layers slowly build a collage of all the content from a given volume, and their overlapping margins <a href="/loc/trim/sanborn03275_001">must be trimmed</a> to create a seamless mosaic.
+					As they are georeferenced, layers slowly build a collage of all the content from a given volume, and their overlapping margins <a href="/loc/trim/sanborn03275_001?utm_source=index">must be trimmed</a> to create a seamless mosaic.
 				</p>
 			</div>
 			<div>
 				<div><i class="i-pinmap i-pinmap-lg"></i></div>
 				<p>
-					Finally, all volume mosaics for a given place are automatically aggregated into a standard web viewer (see <a href="/viewer/baton-rouge-la">Baton Rouge, 1885-1908</a>).
+					Finally, all volume mosaics for a given place are automatically aggregated into a standard web viewer (see <a href="/viewer/baton-rouge-la?utm_source=index">Baton Rouge, 1885-1908</a>).
 				</p>
 			</div>
-			<h4>Want to learn more? Head to the <a href="https://about.oldinsurancemaps.net/docs">full documentation</a> for more information.</h4>
+			<h4>Want to learn more? Head to the <a href="https://about.oldinsurancemaps.net/docs?utm_source=index">full documentation</a> for more information.</h4>
 			<span><em>Icons by <a href="https://thenounproject.com/browse/creator/alex2900/icon-collections/?p=1">Alex Muravev</a> on the Noun Project.</em></span>
 		</div>
 	</div>
-	<div class="map-container" style="margin-bottom: 30px;">
+	<div class="map-container" style="height:{IS_MOBILE ? '600px' : '400px'};">
 		{#if IS_MOBILE}<button class="link-btn" on:click="{() => {showBRMap = !showBRMap}}">{ showBRMapBtnLabel }</button>{/if}
 		{#if showBRMap}
-		<iframe height="{IS_MOBILE ? '600px' : '400px'}" title="Viewer for Sanborn maps of Baton Rouge, Louisiana" style="width:100%; border:none;" src="https://oldinsurancemaps.net/viewer/baton-rouge-la/?year=1898&utm_source=front-page#/center/-91.18179,30.44938/zoom/16"></iframe>
+		<iframe height="100%" title="Viewer for Sanborn maps of Baton Rouge, Louisiana" style="width:100%; border:none;" src="https://oldinsurancemaps.net/viewer/baton-rouge-la/?year=1898&utm_source=index#/center/-91.18179,30.44938/zoom/16"></iframe>
 		{/if}
-		{#if IS_MOBILE}<a href="https://oldinsurancemaps.net/viewer/baton-rouge-la/">Fullscreen view &rarr;</a>{/if}
+		{#if IS_MOBILE}<a href="https://oldinsurancemaps.net/viewer/baton-rouge-la/?utm_source=index">Fullscreen view &rarr;</a>{/if}
 	</div>
 	<!-- <div>
 		<form enctype="multipart/form-data" method="post" action="/newsletter/news-oldinsurancemapsnet/subscribe/">
@@ -94,6 +94,8 @@ $: showBRMapBtnLabel = showBRMap ? "Hide example viewer (Baton Rouge)" : "Show e
 main {
 	display: flex;
 	flex-direction: column;
+	margin-right: -15px;
+	margin-left: -15px;
 }
 
 main > div {
@@ -102,6 +104,10 @@ main > div {
 	padding: 15px;
 	border-top: 1px solid grey;
 	border-bottom: 1px solid grey;
+}
+
+main p {
+	font-size:1.25em;
 }
 
 .hero-banner {
@@ -135,11 +141,6 @@ main > div {
 
 .map-container > span {
 	text-align:center;
-}
-
-.map-link-panel {
-	display: none;
-	text-align: center;
 }
 
 #step-list > div {
@@ -189,16 +190,6 @@ button.link-btn {
 	.hero-banner > div.link-panel {
 		margin-top: 15px;
 	}
-
-	/* .map-container {
-		display: none;
-	} */
-
-
-
-	/* .map-link-panel {
-		display: flex;
-	} */
 }
 
 </style>

--- a/loc_insurancemaps/components/src/Index.svelte
+++ b/loc_insurancemaps/components/src/Index.svelte
@@ -1,8 +1,10 @@
 <script>
 import MapBrowse from './MapBrowse.svelte';
-export let CSRFTOKEN;
 export let PLACES_GEOJSON;
 export let IS_MOBILE;
+export let CSRFTOKEN;
+export let NEWSLETTER_SLUG;
+export let USER_SUBSCRIBED;
 
 let showBrowseMap = !IS_MOBILE;
 $: showBrowseMapBtnLabel = showBrowseMap ? "Hide map finder" : "Show map finder";
@@ -82,12 +84,20 @@ $: showBRMapBtnLabel = showBRMap ? "Hide example viewer (Baton Rouge)" : "Show e
 		{/if}
 		{#if IS_MOBILE}<a href="https://oldinsurancemaps.net/viewer/baton-rouge-la/?utm_source=index">Fullscreen view &rarr;</a>{/if}
 	</div>
-	<!-- <div>
-		<form enctype="multipart/form-data" method="post" action="/newsletter/news-oldinsurancemapsnet/subscribe/">
+	{#if NEWSLETTER_SLUG}
+	<div>
+		<h3>Subscribe to the newsletter for project updates</h3>
+		{#if USER_SUBSCRIBED}
+		<p><em>You are already subscribed. <a href="/newsletter/{NEWSLETTER_SLUG}?utm_source=index">manage subscription</a></em></p>
+		{:else}
+		<form enctype="multipart/form-data"  method="post" action="/newsletter/{NEWSLETTER_SLUG}/subscribe/">
+			<input type="hidden" name="csrfmiddlewaretoken" value={CSRFTOKEN}>
 			<label for="id_email_field">E-mail:</label> <input type="email" name="email_field" required="" id="id_email_field">
 			<button id="id_submit" name="submit" value="Subscribe" type="submit">Subscribe</button>
 		</form>
-	</div> -->
+		{/if}
+	</div>
+	{/if}
 </main>
 <style>
 
@@ -172,7 +182,6 @@ button.link-btn {
 	cursor: pointer;
 	font-size: 1.25em;
 }
-
 
 @media only screen and (max-width: 480px) {
 	main {

--- a/loc_insurancemaps/components/src/Index.svelte
+++ b/loc_insurancemaps/components/src/Index.svelte
@@ -19,7 +19,10 @@ $: showBRMapBtnLabel = showBRMap ? "Hide example viewer (Baton Rouge)" : "Show e
 			<p>Explore historical fire insurance maps of Louisiana as georeferenced web maps overlays. All maps on this site are in the public domain, pulled from the Library of Congress 
 			<a href="https://loc.gov/collections/sanborn-maps">Sanborn Map Collection</a>.</p>
 			<p>These maps were georeferenced by about <a href="/people">70 participants</a> in early 2022&mdash;over four months, 1,500 individual sheets
-				from 270 different Sanborn atlases were processed, resulting in these seamless mosaics.
+				from 270 different Sanborn atlases were processed, resulting in these seamless mosaics.</p>
+			{#if NEWSLETTER_SLUG}
+			<p><a href="#subscribe">Subscribe to project updates</a></p>
+			{/if}
 		</div>
 		<div class="link-panel">
 			<p>Jump to some popular places</p>
@@ -85,7 +88,7 @@ $: showBRMapBtnLabel = showBRMap ? "Hide example viewer (Baton Rouge)" : "Show e
 		{#if IS_MOBILE}<a href="https://oldinsurancemaps.net/viewer/baton-rouge-la/?utm_source=index">Fullscreen view &rarr;</a>{/if}
 	</div>
 	{#if NEWSLETTER_SLUG}
-	<div>
+	<div id="subscribe">
 		<h3>Subscribe to the newsletter for project updates</h3>
 		{#if USER_SUBSCRIBED}
 		<p><em>You are already subscribed. <a href="/newsletter/{NEWSLETTER_SLUG}?utm_source=index">manage subscription</a></em></p>

--- a/loc_insurancemaps/components/src/Participants.svelte
+++ b/loc_insurancemaps/components/src/Participants.svelte
@@ -1,0 +1,97 @@
+<script>
+import {TableSort} from 'svelte-tablesort';
+import TitleBar from "../../../georeference/components/src/TitleBar.svelte"
+
+export let PARTICIPANTS;
+
+let participants = PARTICIPANTS;
+
+console.log(participants)
+function updateFilteredList(filterText) {
+	if (filterText && filterText.length > 0) {
+		participants = [];
+		PARTICIPANTS.forEach( function(p) {
+			const name = p.username.toUpperCase();
+			const filterBy = filterText.toUpperCase();
+			if (name.indexOf(filterBy) > -1) {
+				participants.push(p);
+			}
+		});
+	} else {
+		participants = PARTICIPANTS;
+	}
+}
+let filterInput;
+$: updateFilteredList(filterInput)
+
+function toggleList(userId) {
+	const listEl = document.getElementById(userId);
+	listEl.style.display = listEl.style.display == "flex" ? "none" : "flex";
+	const listBtnEl = document.getElementById(userId+"-btn");
+	listBtnEl.innerText = listBtnEl.innerText == "show all" ? "hide all" : "show all";
+} 
+
+</script>
+<TitleBar TITLE={"Participants"} BOTTOM_LINKS={[]} SIDE_LINKS={[]} ICON_LINKS={[]}/>
+<input type="text" id="filterInput" placeholder="Filter by username..." bind:value={filterInput}>
+<div style="overflow-x:auto;">
+	<TableSort items={participants}>
+		<tr slot="thead">
+			<th data-sort="username" style="max-width:300px;" title="Name of mapped location"></th>
+			<th data-sort="username" style="max-width:300px;" title="Name of mapped location">Username</th>
+			<th data-sort="load_ct" title="Number of unprepared sheets">Loaded Volumes</th>
+			<th data-sort="psesh_ct" style="width:25px; text-align:center; border-left: 1px solid gray;" title="Number of prep sessions">Prep Sessions</th>
+			<th data-sort="gsesh_ct" style="width:25px; text-align:center;" title="Number of georeferencing sessions">Georef. Sessions</th>
+			<th data-sort="total_ct" style="width:25px; text-align:center; border-left:1px solid gray;" title="Percent complete - G/(U+P+G)">Total Sessions</th>
+			<th data-sort="gcp_ct" style="width:25px; text-align:center; border-left:1px solid gray;" title="Ground control points created">GCPs</th>
+		</tr>
+		<tr slot="tbody" let:item={p} style="height:38px;">
+			<td>
+				<img style="height:30px; width:30px;" src={p.avatar} alt={p.username} />
+			</td>
+			<td>
+				<a href={p.profile_url} alt="Profile for {p.username}" title="Profile for {p.username}">
+					{p.username}
+				</a>
+			</td>
+			<td style="">
+				<div>
+				{p.load_ct}{#if p.volumes.length > 0}&nbsp;&mdash;{/if}
+				{#each p.volumes as v, n}
+					{#if n <= 2}
+					<a href={v.url}>{v.title}</a>{#if n != p.volumes.length - 1},&nbsp;{/if}
+					{/if}
+				{/each}
+				{#if p.volumes.length > 3}
+				<button id="{p.username}-btn" on:click={() => toggleList(p.username)}>show all</button>
+				{/if}
+				</div>
+				{#if p.volumes.length > 3}
+				<div id="{p.username}" class="full-volume-list">
+					<ul>
+					{#each p.volumes as v}
+					<li><a href={v.url}>{v.title}</a></li>
+					{/each}
+					</ul>
+				</div>
+				{/if}
+			</td>
+			<td style="text-align:center; border-left:1px solid gray;">{p.psesh_ct}</td>
+			<td style="text-align:center;">{p.gsesh_ct}</td>
+			<td style="text-align:center; border-left:1px solid gray;">{p.total_ct}</td>
+			<td style="text-align:center; border-left:1px solid gray;">{p.gcp_ct}</td>
+		</tr>
+	</TableSort>
+</div>
+<style>
+	.full-volume-list {
+		display: none;
+	}
+
+	tr th {
+		vertical-align: top;
+	}
+	tr td {
+		vertical-align: top;
+	}
+</style>

--- a/loc_insurancemaps/components/src/main-participants.js
+++ b/loc_insurancemaps/components/src/main-participants.js
@@ -1,0 +1,9 @@
+import './css/shared.css';
+import Participants from './Participants.svelte';
+
+const participants = new Participants({
+	target: document.getElementById("participants-target"),
+	props: JSON.parse(document.getElementById("participants-props").textContent),
+});
+
+export default participants;

--- a/loc_insurancemaps/context_processors.py
+++ b/loc_insurancemaps/context_processors.py
@@ -1,22 +1,23 @@
-from django.conf import settings
-
 from georeference.utils import full_reverse
 
 def loc_info(request):
 
-    if request.user.is_authenticated:
-        user = {
+    try:
+        user = request.user
+    except AttributeError:
+        user = None
+    if user and user.is_authenticated:
+        user_info = {
             'is_authenticated': True,
-            'name': request.user.username,
-            'profile': full_reverse("profile_detail", args=(request.user.username, )),
+            'name': user.username,
+            'profile': full_reverse("profile_detail", args=(user.username, )),
         }
     else:
-        user = {
+        user_info = {
             'is_authenticated': False
         }
     return {
-        'newsletter_enabled': settings.ENABLE_NEWSLETTER,
         'navbar_params': {
-            'USER': user
+            'USER': user_info
         }
     }

--- a/loc_insurancemaps/management/commands/add_users_to_newsletter.py
+++ b/loc_insurancemaps/management/commands/add_users_to_newsletter.py
@@ -1,0 +1,26 @@
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
+
+from newsletter.models import Newsletter, Subscription
+
+class Command(BaseCommand):
+    help = 'command to search the Library of Congress API.'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "newsletter-slug",
+            help="identifier for the newsletter to subscribe users to",
+        )
+
+    def handle(self, *args, **options):
+
+        for user in get_user_model().objects.all().exclude(username="AnonymousUser"):
+            newsletter = Newsletter.objects.get(slug=options['newsletter-slug'])
+            sub, created = Subscription.objects.get_or_create(
+                user=user,
+                newsletter=newsletter,
+                defaults={"subscribed": True}
+            )
+            if created:
+                print(sub)

--- a/loc_insurancemaps/management/commands/configure.py
+++ b/loc_insurancemaps/management/commands/configure.py
@@ -317,6 +317,7 @@ sudo supervisorctl reload
             ("SWAP_COORDINATE_ORDER", False),
             ("ENABLE_CPROFILER", False),
             ("ENABLE_DEBUG_TOOLBAR", False),
+            ("ENABLE_NEWSLETTER", False),
         ]
 
         if self.resolve_var("EMAIL_ENABLE", False) is True:

--- a/loc_insurancemaps/management/commands/oneoffs.py
+++ b/loc_insurancemaps/management/commands/oneoffs.py
@@ -9,13 +9,7 @@ from django.core.management.base import BaseCommand, CommandError
 from django.template.loader import render_to_string
 from django.test.client import RequestFactory
 
-from geonode.documents.models import Document
-from geonode.layers.models import Layer
-
-from loc_insurancemaps.models import FullThumbnail, Volume, Place
-from loc_insurancemaps.renderers import generate_layer_geotiff_thumbnail
-
-from loc_insurancemaps.enumerations import STATE_CHOICES
+from loc_insurancemaps.models import Volume, Place
 
 class Command(BaseCommand):
     help = 'command to search the Library of Congress API.'
@@ -24,9 +18,6 @@ class Command(BaseCommand):
         parser.add_argument(
             "operation",
             choices=[
-                "fix-full-thumbnails",
-                "fix-document-thumbnails",
-                "fix-layer-thumbnails",
                 "generate-500.html",
                 "initialize-s3-bucket",
                 "migrate-places",
@@ -42,58 +33,6 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
 
         print(f"operation: {options['operation']}")
-
-        if options['operation'] == "fix-full-thumbnails":
-            docs = Document.objects.all()
-            print(f"{docs.count()} documents")
-            ext = 0
-            new = 0
-            for d in docs:
-                if "missing" in d.thumbnail_url:
-                   print(d)
-                try:
-                    thumb = FullThumbnail.objects.get(document=d)
-                    thumb.save()
-                    ext += 1
-                except FullThumbnail.DoesNotExist:
-                    thumb = FullThumbnail(document=d)
-                    thumb.save()
-                    new += 1
-                #d.thumbnail_url = thumb.image.url
-                #d.save(update_fields=["thumbnail_url"])
-            print(f"{ext} existing FullThumbnails")
-            print(f"{new} new FullThumbnails created")
-
-            print("updating all volume lookups...")
-            for v in Volume.objects.all():
-                v.populate_lookups()
-            print("complete.")
-
-        if options['operation'] == "fix-document-thumbnails":
-            docs = Document.objects.all()
-            print(f"{docs.count()} documents")
-            mis = 0
-            for d in docs:
-                if "missing" in d.thumbnail_url:
-                    mis += 1
-                    d.save()
-            print(f"{mis} missing thumbnail(s) created")
-
-        if options['operation'] == "fix-layer-thumbnails":
-            if options['layerid'] is not None:
-                print(f"forcing regneration of {options['layerid']} thumbnail")
-                layers = Layer.objects.filter(alternate=options['layerid'])
-            else:
-                layers = Layer.objects.all()
-                print(f"checking {layers.count()} layers")
-                layers = [i for i in layers if "missing" in i.thumbnail_url]
-                print(f"{len(layers)} layers with missing thumbnails.")
-            fixed = 0
-            for l in layers:
-                print(f"regenerating thumb for {l.alternate}")
-                generate_layer_geotiff_thumbnail(l)
-                fixed += 1
-            print(f"{fixed} missing thumbnail(s) created")
 
         if options['operation'] == "generate-500.html":
             rf = RequestFactory()

--- a/loc_insurancemaps/settings.py
+++ b/loc_insurancemaps/settings.py
@@ -118,12 +118,12 @@ INSTALLED_APPS = [
     'geonode.groups',
     'geonode.services', # error when removing this app still
     'geonode.geoserver', # needed by geonode.api
-    # 'geonode.upload',
+    'geonode.upload', # needed to delete users (attached to profile??)
     # 'geonode.tasks',
     'geonode.messaging',
-    # 'geonode.monitoring',
+    'geonode.monitoring', # needed to delete users (attached to profile??)
     'geonode.documents.exif',
-    # 'geonode.favorite',
+    'geonode.favorite', # needed to delete users (attached to profile??)
     # 'mapstore2_adapter',
     # 'mapstore2_adapter.geoapps',
     # 'mapstore2_adapter.geoapps.geostories',

--- a/loc_insurancemaps/static/css/site_base.css
+++ b/loc_insurancemaps/static/css/site_base.css
@@ -295,3 +295,15 @@ nav.lahmg-nav div div {
 		transform: translate(24px, 0);
 	}
 }
+
+#newsletter-container {
+	padding-top: 15px;
+}
+#newsletter-container table {
+	width: 100%;
+}
+#newsletter-container th {
+	font-size: 1.1em;
+	background-color: #eaeaea;
+	padding: 5px;
+}

--- a/loc_insurancemaps/static/css/site_base.css
+++ b/loc_insurancemaps/static/css/site_base.css
@@ -29,39 +29,6 @@ h1, h2, h3, h4, h5, h6 {
 .banner-wrap {
 	position: relative
 }
-.banner {
-	display: flex;
-	flex-direction: column;
-	margin-right: -15px;
-	margin-left: -15px;
-	color: inherit;
-	box-shadow: gray 0px 0px 5px;
-	position: relative;
-	/* height: calc(100vh - 30px); */
-}
-.banner-button-list div {
-	align-content: center;
-	align-items: center;
-	display: flex;
-	flex-direction: column;
-}
-.banner p {
-	font-size:1.25em;
-}
-.banner > * {
-	z-index: 100;
-	position: relative;
-}
-.banner-item {
-	margin-top: 45px;
-	padding: 20px;
-	background: rgba(247,241,255,.5)
-}
-.banner-button-list {
-	display:flex;
-	justify-content: space-evenly;
-	
-}
 @media (max-width: 991px) {
 	.banner-button-list {
 	  flex-direction: column;

--- a/loc_insurancemaps/templates/500.html
+++ b/loc_insurancemaps/templates/500.html
@@ -1,7 +1,3 @@
-
-
-
-
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -18,8 +14,6 @@
     <meta property="og:description" content="A crowdsourcing site for creating and viewing georeferenced mosaics of historical Sanborn fire insurance maps" />
 
     <link rel="shortcut icon" href="/static/favicon.ico" />
-    <link href="/static/lib/css/ol.css" rel="stylesheet" />
-    <script src="/static/lib/js/ol.js"></script>
     <link rel="preload" as="style" href="/static/geonode/css/font-awesome.min.css" />
 
     <! -- analytics with plausible.io -->
@@ -29,100 +23,6 @@
 
       <link href="/static/lib/css/assets.min.css" rel="stylesheet"/>
       <link href="/static/geonode/css/base.css" rel="stylesheet"/>
-      <link rel='stylesheet' id='cookie-law-info-css'  href="/static/geonode/css/cookie-law-info/cookie-law-info-public.css" type='text/css' media='all' />
-      <link rel='stylesheet' id='cookie-law-info-gdpr-css'  href="/static/geonode/css/cookie-law-info/cookie-law-info-gdpr.css" type='text/css' media='all' />
-      <style type="text/css">[ng\:cloak],[ng-cloak],[data-ng-cloak],[x-ng-cloak],.ng-cloak,.x-ng-cloak,.ng-hide:not(.ng-hide-animate){display:none !important;}</style>
-      <style type="text/css">
-        /* Additional styles by custom themes */
-        
-        body {
-          background: #ffffff;
-          
-          color: #3a3a3a;
-          
-        }
-
-        .home #partners {
-          background: #ffffff;
-          padding: 2em 0;
-          text-align: center;
-        }
-        
-
-        
-        .home .navbar-inverse , .navbar-inverse {
-          background-color: #123B4F;
-        }
-        
-
-        
-        .navbar-inverse .navbar-nav > li > a {
-          color: #ffffff;
-          font-weight: 600;
-          padding-top: 25px;
-          padding-bottom: 25px;
-        }
-        
-
-        
-        .navbar-inverse .navbar-nav > li > a:hover {
-          background-color: #2c689c;
-        }
-        
-        
-        
-        .navbar-nav .dropdown-menu {
-          background-color: #2c689c;
-          border-top: 1px solid #2c689c;
-        }
-        
-
-        
-        .navbar-nav .dropdown-menu a {
-          color: #ffffff;
-        }
-        
-        
-
-        
-        .navbar-nav .dropdown-menu .divider {
-          background-color: #ffffff;
-        }
-        
-
-        
-
-        
-        .home .big-search {
-          background: #ffffff;
-          color: #007363;
-          padding-bottom: 3em;
-          padding-top: 1em;
-        }
-        .home .big-search .btn-default {
-          background: transparent;
-          border: none;
-          color: #007363;
-        }
-        
-
-        
-        .footer-copyright {
-          background-color: #123B4F;
-        }
-        
-
-        
-        footer {
-          background-color: #123B4F;
-          color: #ffffff;
-          padding: 1.5em;
-        }
-        footer a {
-          color: #EAE0C1;
-        }
-        
-      </style>
 
       <link rel="preconnect" href="https://fonts.googleapis.com">
       <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -141,28 +41,11 @@
         }
       </style>
     <![endif]-->
-    <link rel="search" type="application/opensearchdescription+xml" href="https://oldinsurancemaps.net/catalogue/opensearch" title="GeoNode Search"/>
+    <link rel="search" type="application/opensearchdescription+xml" href="http://localhost:8000/catalogue/opensearch" title="GeoNode Search"/>
 
     <script>
-        var siteUrl = 'https://oldinsurancemaps.net/'.replace(/\/?$/, '/');
+        var siteUrl = 'http://localhost:8000/'.replace(/\/?$/, '/');
         var staticUrl = '/static/';
-    </script>
-
-    <!-- Autocomplete script for input boxes -->
-    <script src="/static/geonode/js/search/autocomplete.js"></script>
-
-    <script type="text/javascript">
-      function thumbnailFeedbacks(data, status) {
-        try {
-          $("#_thumbnail_feedbacks").find('.modal-title').text(status);
-          $("#_thumbnail_feedbacks").find('.modal-body').text(data);
-          $("#_thumbnail_feedbacks").modal("show");
-        } catch (err) {
-          console.log(err);
-        } finally {
-          return true;
-        }
-      }
     </script>
 
     <!-- RTL styles -->
@@ -175,36 +58,20 @@
     <div class='lmask'></div>
     <!-- Navbar -->
     
+
     
-      
 
-      <!-- End of Navbar -->
-    <nav class="lahmg-nav">
 
-      <div>
-        <div>
-          <a href="/" title="LaHMG">
-            <img src="/static/img/noun_Map_heavy-colored-lite.png" alt="LaHMG" class="navbar-brand-new">
-            &nbsp;&nbsp;
-            <strong>Home</strong>
-          </a>
-        </div>
-        <div>
-          <a href="/browse/" title="Browse Maps">Browse Maps</a>
-        </div>
-        <div>
-          <a href="https://about.oldinsurancemaps.net" title="Browse">About</a>
-        </div>
-      </div>
-      <div>
-        
-        <div>
-          <a href="#" data-toggle="modal" data-target="#SigninModal" role="button" >Sign in</a>
-        </div>
-        
-      </div>
 
-    </nav>
+    
+    <link href="/static/Navbar.css" rel="stylesheet">
+
+
+<div id="navbar-target"></div>
+
+<script id="navbar-props" type="application/json">{"USER": {"is_authenticated": false}}</script>
+<script type="text/javascript" src="/static/Navbar.js"></script>
+
 
 
     <div class="alert alert-danger alert-dismissible" role="alert" id="ieflag" style="display:none">
@@ -214,7 +81,7 @@
     </div>
 
     
-    <div class="container">
+    <div class="container background-fg" style="min-height: calc(100vh - 250px);">
       
 <div class="alert alert-warn" id="status-message" hidden="hidden">
     <a class="close" onclick="$('.alert').hide()">×</a>
@@ -226,27 +93,10 @@
 
 
 
-<div id="site_wide_announcements">
-    
-    
-    <div class="alert alert-block announcement alert-warning">
-        
-        <a type="button" class="close" data-dismiss="alert" data-dismiss-url="/announcements/announcement/9/hide/" href="#">×</a>
-        
-        <h4><a href="/announcements/announcement/9/">Site Changes</a></h4>
-        <p><small><em>June 27, 2022, 8:57 p.m.</em></small></p>
-        <div>Thank you for your interest! This site will be undergoing development through the summer and fall, but you'll be able to continue exploring Sanborn maps here. Follow <a href="https://twitter.com/mradamcox" target="_blank">@mradamcox</a> for future updates.</div>
-    </div>
-    
-    
-</div>
-
 
       
 
       
-      <div class="row">
-        <div class="col-md-8">
         
   <div id="description"><h3>Server Error</h3></div>
   
@@ -255,11 +105,8 @@
       
   
 
-        </div>
-        <div class="col-md-4">
         
-        </div>
-      </div>
+      
       
     </div>
     
@@ -269,52 +116,23 @@
 
   
   
+
+
   
-<footer>
-  <div class="container">
-    <div class="row">
-      <div class="col-md-4">
-        <ul class="list-unstyled">
-          <li>Content</li>
-          <li><a href="/loc/volumes/">Volumes</a></li>
-          <li><a href="/documents/?limit=20">Documents</a></li>
-          <li><a href="/layers/?limit=20">Layers</a></li>
-          <li><a href="/maps/?limit=20">Web Maps</a></li>
-          
-          
-        </ul>
-      </div>
-      <div class="col-md-4">
-        <ul class="list-unstyled">
-          <li>About</li>
-          <li><a href="/getting-started/">Getting Started</a></li>
-          <li><a href="/about/">Project Background</a></li>
-          <li><a href="https://docs.oldinsurancemaps.net">Documentation</a></li>
-          <li role="separator" class="divider"></li>
-          <li><a href="/people/">People</a></li>
-          <li><a href="/groups/">Groups</a></li>
-          
-          
-          
-        </ul>
-      </div>
+  
 
-      <div class="col-md-4 text-right">
-        <ul class="list-unstyled">
-            <li style="text-align: left;"><h3 style="margin-top: 0px;">Get in touch! </h3> </li>
-            <li style="text-align: left;"><a href="mailto:hello@oldinsurancemaps.net">hello@oldinsurancemaps.net</a></li>
-        </ul>
-      </div>
-    </div>
-    <div class="row" style="color:white; text-align:center;">
-      <div class="col-xs-12">
-        <p>Copyright © 2022 | <a href="https://github.com/mradamcox/loc-insurancemaps" target="_blank">Source <i class="fa fa-external-link"></i></a> |
-           Powered by <a href="https://geonode.org" target="_blank">GeoNode <i class="fa fa-external-link"></i></a></p>
-      </div>
-    </div>
-  </div>
-</footer>
 
+
+    
+    <link href="/static/Footer.css" rel="stylesheet">
+
+
+<div id="footer-target"></div>
+
+<script id="footer-props" type="application/json">{"USER": {"is_authenticated": false}}</script>
+<script type="text/javascript" src="/static/Footer.js"></script>
+
+  
 
 
     <!-- Modal must stay outside the navbar -->
@@ -328,7 +146,7 @@
           </div>
           <form class="form-signin" role="form" action="/account/login/?next=/" method="post">
             <div class="modal-body">
-              <input type="hidden" name="csrfmiddlewaretoken" value="KhiDgqN4JyJDINT68vfjtb4HjkuJxdnSPyXeNzQQjZ8OtK3zLb5P5sqluVqrQgIr">
+              <input type="hidden" name="csrfmiddlewaretoken" value="tPkIzBlf5BSERi7iastue7l7tvvYPRqYD0iEMupZBmYuCHRGa786WT6A1wGzaEuh">
               
               
               <div class="form-group">
@@ -340,7 +158,7 @@
                 <input id="id_password" class="form-control" name="password" placeholder="Password" type="password" autocomplete="off" />
               </div>
               <label class="checkbox" style="padding-left:20px;">
-                <input type="checkbox" style="margin-left-20px;" /> Remember Me
+                <input type="checkbox" /> Remember Me
               </label>
               <p>
                 <a href="/account/password/reset/">Forgot Password?</a>
@@ -362,44 +180,18 @@
     
     <!-- End of Modal -->
 
+    <!-- quick testing shows that only jquery and bootstrap are needed to 
+    retain the sign in modal functionality. This allows for the removal of
+    assets.js which was originally included below. -->
+    <script src="/static/lib/js/jquery.js"></script>
+    <script src="/static/lib/js/bootstrap.js"></script>
+
     
-    <script src="/static/lib/js/assets.min.js"></script>
+    <!-- <script src="/static/geonode/js/utils/utils.js"></script>
+    <script src="/static/geonode/js/base/base.js"></script> -->
+    <!-- <script type="text/javascript" src="/jsi18n/"></script> -->
     
-    <script src="/static/geonode/js/utils/utils.js"></script>
-    <script src="/static/geonode/js/base/base.js"></script>
-    <script type="text/javascript" src="/jsi18n/"></script>
-    
-    <!-- <script type="text/javascript">
 
-      // Autocomplete instance for the search found in the header.
-      $(document).ready(function() {
-        window.autocomplete2 = new Autocomplete({
-          form_btn: null,
-          form_submit: '#search',
-          form_selector: '#search',
-          input_selector: '#search_input',
-          container_selector: '#search-container',
-          url: '/base/autocomplete_response/'
-        })
-        window.autocomplete2.setup()
-      })
-
-      $('#search').on('submit', (e) => {
-          $('#search_abstract_input')[0].value =$('#search_input')[0].value;
-          $('#search_purpose_input')[0].value = $('#search_input')[0].value;
-      });
-
-      $(window).on('load', function() {
-          setTimeout(() => {
-              document.body.scrollTop = 0;
-              document.documentElement.scrollTop = 0;
-          });
-        });
-
-      $(".datepicker").datepicker({
-          format: "yyyy-mm-dd"
-      });
-    </script> -->
 
     <div class="modal fade" style="width: 100%; height: 100%;" id="_resource_uploading" data-backdrop="static" data-keyboard="false" aria-hidden="true">
         <div class="modal-dialog">

--- a/loc_insurancemaps/templates/500.html.template
+++ b/loc_insurancemaps/templates/500.html.template
@@ -1,4 +1,4 @@
-{% extends "geonode_base.html" %}
+{% extends "base.html" %}
 {% load i18n %}
 
 {% block body %}

--- a/loc_insurancemaps/templates/account/signup.html
+++ b/loc_insurancemaps/templates/account/signup.html
@@ -1,0 +1,49 @@
+{% extends "account/base.html" %}
+
+{% load i18n %}
+{% load bootstrap_tags %}
+{% load account socialaccount %}
+
+{% block title %}{% trans "Sign up" %}{% endblock %}
+
+{% block body_outer %}
+    <div class="page-header">
+        <h2>{% trans "Sign up" %}</h2>
+    </div>
+    <div class="row">
+      {% get_providers as socialaccount_providers %}
+      {% if socialaccount_providers %}
+          <p>{% blocktrans with site.name as site_name %}Sign up with one
+              of your existing third party accounts{% endblocktrans %}</p>
+          {% include "socialaccount/snippets/provider_list.html" with process="signup" %}
+          {% include "socialaccount/snippets/login_extra.html" %}
+          <hr>
+      {% endif %}
+    </div>
+    {% if account_geonode_local_signup %}
+        <div class="row">
+          <p>{% trans "Create a new local account" %}</p>
+          <form id="signup_form" method="post" action="{% url "account_signup" %}" autocapitalize="off" {% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
+              <fieldset>
+                  {% csrf_token %}
+                  {{ form|as_bootstrap }}
+                  {% if redirect_field_value %}
+                      <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
+                  {% endif %}
+                  <div class="form-actions">
+                      <button type="submit" class="btn btn-primary">{% trans "Sign up" %}</button>
+                  </div>
+              </fieldset>
+          </form>
+        </div>
+    {% endif %}
+{% endblock %}
+
+{% block extra_script %}
+    {{ block.super }}
+    <script type="text/javascript">
+        document.addEventListener("DOMContentLoaded", () => {
+            document.getElementById("id_email").focus()
+        });
+    </script>
+{% endblock %}

--- a/loc_insurancemaps/templates/base.html
+++ b/loc_insurancemaps/templates/base.html
@@ -51,7 +51,7 @@
 
     <script>
         var siteUrl = '{{ SITEURL }}'.replace(/\/?$/, '/');
-        var staticUrl = '{% static '' %}';
+        var staticUrl = '{% static "" %}';
     </script>
 
     <!-- RTL styles -->
@@ -82,20 +82,15 @@
     </div>
 
     {% block middle %}
-    <div class="container">
+    <div class="container background-fg" style="min-height: calc(100vh - 250px);">
       {% include "_status_message.html" %}
       {% include "_announcements.html" %}
       {% include "_messages.html" %}
       {% block body_outer %}
-      <div class="row">
-        <div class="col-md-8">
-        {% block body %}{% endblock %}
-        </div>
-        <div class="col-md-4">
-        {% block sidebar %}{% endblock %}
-        </div>
-      </div>
-      {% endblock %}
+        {% block body %}{% endblock body %}
+        {% block sidebar %}{% endblock sidebar %}
+      {% endblock body_outer %}
+      {% block main_content %}{% endblock %}
     </div>
     {% endblock middle %}
 
@@ -138,7 +133,7 @@
                 <input id="id_password" class="form-control" name="password" placeholder="{% trans "Password" %}" type="password" autocomplete="off" />
               </div>
               <label class="checkbox" style="padding-left:20px;">
-                <input type="checkbox" style="margin-left-20px;" /> {% trans "Remember Me" %}
+                <input type="checkbox" /> {% trans "Remember Me" %}
               </label>
               <p>
                 <a href="{% url 'account_reset_password' %}">{% trans "Forgot Password?" %}</a>

--- a/loc_insurancemaps/templates/browse.html
+++ b/loc_insurancemaps/templates/browse.html
@@ -1,15 +1,9 @@
-{% extends 'index.html' %}
-{% load markdownify %}
+{% extends 'base.html' %}
 {% load i18n %}
-{% load base_tags %}
 {% load django_svelte %}
 
 {% block title %}Browse{% endblock title %}
 
-{% block hero %}
+{% block main_content %}
   {% display_svelte "Browse.svelte" browse_params %}
-{% endblock hero %}
-
-{% block bigsearch %}{% endblock bigsearch %}
-{% block showcase %}{% endblock showcase %}
-{% block datasets %}{% endblock datasets %}
+{% endblock %}

--- a/loc_insurancemaps/templates/index.html
+++ b/loc_insurancemaps/templates/index.html
@@ -1,34 +1,11 @@
 {% extends "base.html" %}
-{% load markdownify %}
 {% load i18n %}
-{% load static from staticfiles %}
-{% load base_tags %}
 {% load django_svelte %}
 
 {% block title %}{{ block.super }}{% endblock %}
 
 {% block body_class %}home{% endblock %}
 
-
-{% block middle %}
-<div class="container-outer">
-  {{ block.super }}
-  {% block middlefull %}
-  <div class="container background-fg">
-  {% block hero %}
-
-
-{% display_svelte "Index.svelte" svelte_params %}
-
-  {% endblock hero %}
-
-  {% block mainbody %}
-
-  {% block bigsearch %}
-  {% endblock bigsearch %}
-
-  {% endblock mainbody %}
-</div>
-{% endblock middlefull %}
-</div>
-{% endblock middle %}
+{% block main_content %}
+    {% display_svelte "Index.svelte" svelte_params %}
+{% endblock %}

--- a/loc_insurancemaps/templates/lc/volume_summary.html
+++ b/loc_insurancemaps/templates/lc/volume_summary.html
@@ -1,15 +1,9 @@
-{% extends 'index.html' %}
-{% load markdownify %}
+{% extends 'base.html' %}
 {% load i18n %}
-{% load base_tags %}
 {% load django_svelte %}
 
 {% block title %}{{ svelte_params.VOLUME.title }}{% endblock title %}
 
-{% block hero%}
+{% block main_content %}
   {% display_svelte "Volume.svelte" svelte_params %} 
-{% endblock hero %}
-
-{% block bigsearch %}{% endblock bigsearch %}
-{% block showcase %}{% endblock showcase %}
-{% block datasets %}{% endblock datasets %}
+{% endblock %}

--- a/loc_insurancemaps/templates/newsletter/common.html
+++ b/loc_insurancemaps/templates/newsletter/common.html
@@ -1,0 +1,2 @@
+{% extends 'base.html' %}
+{% load i18n %}

--- a/loc_insurancemaps/templates/newsletter/common.html
+++ b/loc_insurancemaps/templates/newsletter/common.html
@@ -1,2 +1,8 @@
 {% extends 'base.html' %}
 {% load i18n %}
+{% block body_outer %}
+<div id="newsletter-container">
+{% block body %}{% endblock body %}
+{% block sidebar %}{% endblock sidebar %}
+</div>
+{% endblock body_outer %}

--- a/loc_insurancemaps/templates/newsletter/message/message.html
+++ b/loc_insurancemaps/templates/newsletter/message/message.html
@@ -1,0 +1,32 @@
+{% load thumbnail i18n %}<!DOCTYPE html>
+
+<html>
+<head>
+    <meta charset="utf-8">
+	<title>{{ newsletter.title }}: {{ message.title }}</title>
+</head>
+<body>
+    <h1>{{ newsletter.title }}</h1>
+    <h2>{{ message.title }}</h2>
+    {% for article in message.articles.all %}
+        <h3>{{ article.title }}</h3>
+        
+        {% thumbnail article.image "200x200" as image %}
+            <img src="http://{{ site.domain }}{{ image.url }}" width="{{ image.width }}" height="{{ image.height }}">
+        {% endthumbnail %}
+
+        <div>{{ article.text|safe }}</div>
+        
+        {% if article.url %}
+            <div><a href="{{ article.url }}">{% trans "Read more" %}</a></div>
+        {% endif %}
+    {% endfor %}
+    
+    <ul>
+        {% if submission.publish %}
+        <li><a href="http://{{ site.domain }}{{ submission.get_absolute_url }}">{% trans "Read message online" %}</a></li>
+        {% endif %}
+        <li><a href="http://{{ site.domain }}{% url "newsletter_unsubscribe_request" newsletter.slug %}">{% trans "Unsubscribe" %}</a></li>
+    </ul>
+</body>
+</html>

--- a/loc_insurancemaps/templates/newsletter/message/message.txt
+++ b/loc_insurancemaps/templates/newsletter/message/message.txt
@@ -1,0 +1,15 @@
+{% load i18n %}++++++++++++++++++++
+
+{{ newsletter.title }}: {{ message.title }}
+
+++++++++++++++++++++
+
+{% for article in message.articles.all %}
+{{ article.title }}
+{{ article.text|striptags|safe }}
+
+{% endfor %}
+
+++++++++++++++++++++
+
+{% trans "Unsubscribe:" %} http://{{ site }}{% url "newsletter_unsubscribe_request" newsletter.slug %}

--- a/loc_insurancemaps/templates/newsletter/message/message_subject.txt
+++ b/loc_insurancemaps/templates/newsletter/message/message_subject.txt
@@ -1,0 +1,1 @@
+{{ newsletter.title }} - {{ message.title }}

--- a/loc_insurancemaps/templates/newsletter/message/subscribe.html
+++ b/loc_insurancemaps/templates/newsletter/message/subscribe.html
@@ -1,0 +1,20 @@
+{% load i18n %}<!DOCTYPE html>
+
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>{% blocktrans with title=newsletter.title %}Subscription to {{ title }}{% endblocktrans %}
+</title>
+</head>
+<body>
+{% blocktrans with name=subscription.name|default:_("Sir/Madam") title=newsletter.title domain=site.domain url=subscription.subscribe_activate_url %}Dear {{ name }},
+
+you, or someone in your name requested a subscription to {{ title }}.
+
+If you would like to confirm your subscription, please follow this activation link:
+http://{{ domain }}{{ url }}
+
+Kind regards,{% endblocktrans %}
+{{ newsletter.sender }}
+</body>
+</html>

--- a/loc_insurancemaps/templates/newsletter/message/subscribe.html
+++ b/loc_insurancemaps/templates/newsletter/message/subscribe.html
@@ -7,14 +7,16 @@
 </title>
 </head>
 <body>
-{% blocktrans with name=subscription.name|default:_("Sir/Madam") title=newsletter.title domain=site.domain url=subscription.subscribe_activate_url %}Dear {{ name }},
+{% blocktrans with title=newsletter.title domain=site.domain url=subscription.subscribe_activate_url %}Hello!
 
-you, or someone in your name requested a subscription to {{ title }}.
+You requested a subscription to {{ title }}.
 
-If you would like to confirm your subscription, please follow this activation link:
+To confirm your subscription, please follow this activation link:
 http://{{ domain }}{{ url }}
 
-Kind regards,{% endblocktrans %}
-{{ newsletter.sender }}
+Thanks!
+{% endblocktrans %}
+
+http://{{ domain }}
 </body>
 </html>

--- a/loc_insurancemaps/templates/newsletter/message/subscribe.txt
+++ b/loc_insurancemaps/templates/newsletter/message/subscribe.txt
@@ -1,0 +1,9 @@
+{% load i18n %}{% blocktrans with name=subscription.name|default:_("Sir/Madam") title=newsletter.title domain=site.domain url=subscription.subscribe_activate_url %}Dear {{ name }},
+
+you, or someone in your name requested a subscription to {{ title }}.
+
+If you would like to confirm your subscription, please follow this activation link:
+http://{{ domain }}{{ url }}
+
+Kind regards,{% endblocktrans %}
+{{ newsletter.sender }}

--- a/loc_insurancemaps/templates/newsletter/message/subscribe.txt
+++ b/loc_insurancemaps/templates/newsletter/message/subscribe.txt
@@ -1,9 +1,12 @@
-{% load i18n %}{% blocktrans with name=subscription.name|default:_("Sir/Madam") title=newsletter.title domain=site.domain url=subscription.subscribe_activate_url %}Dear {{ name }},
+{% load i18n %}
+{% blocktrans with title=newsletter.title domain=site.domain url=subscription.subscribe_activate_url %}Hello!
 
-you, or someone in your name requested a subscription to {{ title }}.
+You requested a subscription to {{ title }}.
 
-If you would like to confirm your subscription, please follow this activation link:
+To confirm your subscription, please follow this activation link:
 http://{{ domain }}{{ url }}
 
-Kind regards,{% endblocktrans %}
-{{ newsletter.sender }}
+Thanks!
+{% endblocktrans %}
+
+http://{{ domain }}

--- a/loc_insurancemaps/templates/newsletter/message/subscribe_subject.txt
+++ b/loc_insurancemaps/templates/newsletter/message/subscribe_subject.txt
@@ -1,0 +1,1 @@
+{% load i18n %}{{ newsletter.title }} - {% trans "Confirm subscription" %}

--- a/loc_insurancemaps/templates/newsletter/message/unsubscribe.html
+++ b/loc_insurancemaps/templates/newsletter/message/unsubscribe.html
@@ -1,0 +1,19 @@
+{% load i18n %}<!DOCTYPE html>
+
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>{% blocktrans with title=newsletter.title %}Unsubscription from {{ title }}{% endblocktrans %}</title>
+</head>
+<body>
+{% blocktrans with name=subscription.name|default:_("Sir/Madam") title=newsletter.title domain=site.domain url=subscription.unsubscribe_activate_url %}Dear {{ name }},
+
+you, or someone in your name requested unsubscription from {{ title }}.
+
+If you would like to confirm your unsubscription, please follow this activation link:
+http://{{ domain }}{{ url }}
+
+Kind regards,{% endblocktrans %}
+{{ newsletter.sender }}
+</body>
+</html>

--- a/loc_insurancemaps/templates/newsletter/message/unsubscribe.html
+++ b/loc_insurancemaps/templates/newsletter/message/unsubscribe.html
@@ -6,14 +6,16 @@
     <title>{% blocktrans with title=newsletter.title %}Unsubscription from {{ title }}{% endblocktrans %}</title>
 </head>
 <body>
-{% blocktrans with name=subscription.name|default:_("Sir/Madam") title=newsletter.title domain=site.domain url=subscription.unsubscribe_activate_url %}Dear {{ name }},
+{% blocktrans with title=newsletter.title domain=site.domain url=subscription.subscribe_activate_url %}Hello!
 
-you, or someone in your name requested unsubscription from {{ title }}.
+You have requested to unsubscribe from {{ title }}.
 
-If you would like to confirm your unsubscription, please follow this activation link:
+To confirm your unsubscription, please follow this activation link:
 http://{{ domain }}{{ url }}
 
-Kind regards,{% endblocktrans %}
-{{ newsletter.sender }}
+Thanks!
+{% endblocktrans %}
+
+https://{{ domain }}
 </body>
 </html>

--- a/loc_insurancemaps/templates/newsletter/message/unsubscribe.txt
+++ b/loc_insurancemaps/templates/newsletter/message/unsubscribe.txt
@@ -1,0 +1,9 @@
+{% load i18n %}{% blocktrans with name=subscription.name|default:_("Sir/Madam") title=newsletter.title domain=site.domain url=subscription.unsubscribe_activate_url %}Dear {{ name }},
+
+you, or someone in your name requested unsubscription from {{ title }}.
+
+If you would like to confirm your unsubscription, please follow this activation link:
+http://{{ domain }}{{ url }}
+
+Kind regards,{% endblocktrans %}
+{{ newsletter.sender }}

--- a/loc_insurancemaps/templates/newsletter/message/unsubscribe.txt
+++ b/loc_insurancemaps/templates/newsletter/message/unsubscribe.txt
@@ -1,9 +1,12 @@
-{% load i18n %}{% blocktrans with name=subscription.name|default:_("Sir/Madam") title=newsletter.title domain=site.domain url=subscription.unsubscribe_activate_url %}Dear {{ name }},
+{% load i18n %}
+{% blocktrans with title=newsletter.title domain=site.domain url=subscription.subscribe_activate_url %}Hello!
 
-you, or someone in your name requested unsubscription from {{ title }}.
+You have requested to unsubscribe from {{ title }}.
 
-If you would like to confirm your unsubscription, please follow this activation link:
+To confirm your unsubscription, please follow this activation link:
 http://{{ domain }}{{ url }}
 
-Kind regards,{% endblocktrans %}
-{{ newsletter.sender }}
+Thanks!
+{% endblocktrans %}
+
+https://{{ domain }}

--- a/loc_insurancemaps/templates/newsletter/message/unsubscribe_subject.txt
+++ b/loc_insurancemaps/templates/newsletter/message/unsubscribe_subject.txt
@@ -1,0 +1,1 @@
+{% load i18n %}{{ newsletter.title }} - {% trans "Confirm unsubscription" %}

--- a/loc_insurancemaps/templates/newsletter/message/update.html
+++ b/loc_insurancemaps/templates/newsletter/message/update.html
@@ -1,0 +1,19 @@
+{% load i18n %}<!DOCTYPE html>
+
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>{% blocktrans with title=newsletter.title %}Update of subscription to {{ title }}{% endblocktrans %}</title>
+</head>
+<body>
+{% blocktrans with name=subscription.name|default:_("Sir/Madam") title=newsletter.title domain=site.domain url=subscription.update_activate_url %}Dear {{ name }},
+
+you, or someone in your name requested updating your personal information for {{ title }}.
+
+To make changes to your information in our database, please follow this activation link:
+http://{{ domain }}{{ url }}
+
+Kind regards,{% endblocktrans %}
+{{ newsletter.sender }}
+</body>
+</html>

--- a/loc_insurancemaps/templates/newsletter/message/update.html
+++ b/loc_insurancemaps/templates/newsletter/message/update.html
@@ -6,14 +6,17 @@
     <title>{% blocktrans with title=newsletter.title %}Update of subscription to {{ title }}{% endblocktrans %}</title>
 </head>
 <body>
-{% blocktrans with name=subscription.name|default:_("Sir/Madam") title=newsletter.title domain=site.domain url=subscription.update_activate_url %}Dear {{ name }},
+{% blocktrans with title=newsletter.title domain=site.domain url=subscription.subscribe_activate_url %}Hello!
 
-you, or someone in your name requested updating your personal information for {{ title }}.
+You have requested to update your personal information for {{ title }}.
 
-To make changes to your information in our database, please follow this activation link:
+To confirm this update, please follow this activation link:
 http://{{ domain }}{{ url }}
 
-Kind regards,{% endblocktrans %}
-{{ newsletter.sender }}
+Thanks!
+{% endblocktrans %}
+
+https://{{ domain }}
+    
 </body>
 </html>

--- a/loc_insurancemaps/templates/newsletter/message/update.txt
+++ b/loc_insurancemaps/templates/newsletter/message/update.txt
@@ -1,0 +1,9 @@
+{% load i18n %}{% blocktrans with name=subscription.name|default:_("Sir/Madam") title=newsletter.title domain=site.domain url=subscription.update_activate_url %}Dear {{ name }},
+
+you, or someone in your name requested updating your personal information for {{ title }}.
+
+To make changes to your information in our database, please follow this activation link:
+http://{{ domain }}{{ url }}
+
+Kind regards,{% endblocktrans %}
+{{ newsletter.sender }}

--- a/loc_insurancemaps/templates/newsletter/message/update.txt
+++ b/loc_insurancemaps/templates/newsletter/message/update.txt
@@ -1,9 +1,12 @@
-{% load i18n %}{% blocktrans with name=subscription.name|default:_("Sir/Madam") title=newsletter.title domain=site.domain url=subscription.update_activate_url %}Dear {{ name }},
+{% load i18n %}
+{% blocktrans with title=newsletter.title domain=site.domain url=subscription.subscribe_activate_url %}Hello!
 
-you, or someone in your name requested updating your personal information for {{ title }}.
+You have requested to update your personal information for {{ title }}.
 
-To make changes to your information in our database, please follow this activation link:
+To confirm this update, please follow this activation link:
 http://{{ domain }}{{ url }}
 
-Kind regards,{% endblocktrans %}
-{{ newsletter.sender }}
+Thanks!
+{% endblocktrans %}
+
+https://{{ domain }}

--- a/loc_insurancemaps/templates/newsletter/message/update_subject.txt
+++ b/loc_insurancemaps/templates/newsletter/message/update_subject.txt
@@ -1,0 +1,1 @@
+{% load i18n %}{{ newsletter.title }} - {% trans "Update information" %}

--- a/loc_insurancemaps/templates/newsletter/newsletter_detail.html
+++ b/loc_insurancemaps/templates/newsletter/newsletter_detail.html
@@ -1,0 +1,30 @@
+{% extends "newsletter/common.html" %}
+
+{% load i18n %}
+
+{% block title %}{{ object.title }}{% endblock title %}
+
+{% block body %}
+<table>
+    <tr>
+        <th>{{ object.title }}</th>
+    </tr>
+    <tr>
+        <td><a href="{% url "newsletter_subscribe_request" object.slug %}">{% trans "Subscribe" %}</a></td>
+    </tr>
+    {% if not user.is_authenticated %}
+    <tr>
+        <td><a href="{% url "newsletter_update_request" object.slug %}">{% trans "Update" %}</a></td>
+    </tr>
+    {% endif %}
+    <tr>
+        <td><a href="{% url "newsletter_unsubscribe_request" object.slug %}">{% trans "Unsubscribe" %}</a></td>
+    </tr>
+    <tr>
+        <td><a href="{% url "newsletter_archive" object.slug %}">{% trans "Archive" %}</a></td>
+    </tr>
+    <tr>
+        <td><a href="../">{% trans "Back to list" %}</a></td>
+    </tr>
+</table>
+{% endblock body %}

--- a/loc_insurancemaps/templates/newsletter/newsletter_list.html
+++ b/loc_insurancemaps/templates/newsletter/newsletter_list.html
@@ -1,0 +1,41 @@
+{% extends "newsletter/common.html" %}
+
+{% load i18n %}
+
+{% block title %}{% trans "Newsletter list" %}{% endblock title %}
+
+{% block body %}
+{% if user.is_authenticated %}
+<form method="POST" action="">
+  {% csrf_token %}
+  {{ formset.management_form }}
+  <table>
+    <tr>
+        <th>{% trans "Newsletter" %}</th>
+        {% if user %}
+        <th>{% trans "Subscribe" %}</th>
+        {% endif %}
+    </tr>
+    {% for form in formset.forms %}
+      <tr>
+        <td>{{ form.id }}{{ form.newsletter }}
+<a href="{% url "newsletter_detail" form.instance.newsletter.slug %}">{{ form.instance.newsletter.title }}</a></td>
+        <td>{{ form.subscribed }}</td>
+      </tr>
+    {% endfor %}
+  </table>
+  <p><input id="id_submit" name="submit" value="{% trans "Update subscriptions" %}" type="submit" /></p>
+</form>
+{% else %}
+<table>
+    <tr>
+        <th>{% trans "Newsletter" %}</th>
+    </tr>
+    {% for newsletter in object_list %}
+    <tr>
+        <td><a href="{% url "newsletter_detail" newsletter.slug %}">{{ newsletter.title }}</a></td>
+    </tr>
+    {% endfor %}
+</table>
+{% endif %}
+{% endblock body %}

--- a/loc_insurancemaps/templates/newsletter/submission_archive.html
+++ b/loc_insurancemaps/templates/newsletter/submission_archive.html
@@ -11,7 +11,7 @@
     </tr>
     {% for submission in latest %}
     <tr>
-        <td><a href="{{ submission.get_absolute_url }}">{{ submission.message.title }}</a> &mdash; {{submission.message.date_create }}</td>
+        <td><a href="{{ submission.get_absolute_url }}">{{ submission.message.title }}</a> &mdash; {{submission.publish_date}}<td>
     </tr>
     {% endfor %}
     <tr>

--- a/loc_insurancemaps/templates/newsletter/submission_archive.html
+++ b/loc_insurancemaps/templates/newsletter/submission_archive.html
@@ -11,7 +11,7 @@
     </tr>
     {% for submission in latest %}
     <tr>
-        <td><a href="{{ submission.get_absolute_url }}">{{ submission.message.title }}</a> &mdash; {{submission.publish_date}}<td>
+        <td><a href="{{ submission.get_absolute_url }}">{{ submission.message.title }}</a> &mdash; {{submission.publish_date}}</td>
     </tr>
     {% endfor %}
     <tr>

--- a/loc_insurancemaps/templates/newsletter/submission_archive.html
+++ b/loc_insurancemaps/templates/newsletter/submission_archive.html
@@ -1,0 +1,21 @@
+{% extends "newsletter/common.html" %}
+
+{% load i18n %}
+
+{% block title %}{{ newsletter.title }} &mdash; Archive{% endblock title %}
+
+{% block body %}
+<table>
+    <tr>
+        <th>{{ newsletter.title }} &mdash; Archive</th>
+    </tr>
+    {% for submission in latest %}
+    <tr>
+        <td><a href="{{ submission.get_absolute_url }}">{{ submission.message.title }}</a> &mdash; {{submission.message.date_create }}</td>
+    </tr>
+    {% endfor %}
+    <tr>
+        <td><a href="../">{% trans "Back to list" %}</a></td>
+    </tr>
+</table>
+{% endblock body %}

--- a/loc_insurancemaps/templates/newsletter/subscription_activate.html
+++ b/loc_insurancemaps/templates/newsletter/subscription_activate.html
@@ -1,0 +1,15 @@
+{% extends "newsletter/common.html" %}
+
+{% load i18n %}
+
+{% block title %}{{ newsletter.title }} {{ action }} {% trans "activate" %}{% endblock title %}
+
+{% block body %}
+    <h1>{{ newsletter.title }} {{ action }} {% trans "activate" %}</h1>
+
+    <form enctype="multipart/form-data" method="post" action=".">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <p><input id="id_submit" name="submit" value="{% trans "Activate" %}" type="submit" /></p>
+    </form>
+{% endblock body %}

--- a/loc_insurancemaps/templates/newsletter/subscription_subscribe.html
+++ b/loc_insurancemaps/templates/newsletter/subscription_subscribe.html
@@ -1,0 +1,25 @@
+{% extends "newsletter/common.html" %}
+
+{% load i18n %}
+
+{% block title %}{% trans "Subscribe" %} &mdash; {{ newsletter.title }}{% endblock title %}
+
+{% block body %}
+    <h1>{% trans "Subscribe" %} &mdash; {{ newsletter.title }}</h1>
+
+    {% if error %}
+        <p>{% trans "Due to a technical error we were not able to submit your confirmation email. This could be because your email address is invalid." %}</p>
+
+        {% comment %} Replace the the following dummy with a valid email address and remove this comment.
+
+        <p>{% trans "If the error persists, please don't hesitate to contact us at the following email address:" %} <a href="mailto:info@foobar.com">info@foobar.com</a></p>
+
+        {% endcomment %}
+    {% else %}
+        <form enctype="multipart/form-data" method="post" action=".">
+            {% csrf_token %}
+            {{ form.as_p }}
+            <p><input id="id_submit" name="submit" value="{% trans "Subscribe" %}" type="submit" /></p>
+        </form>
+    {% endif %}
+{% endblock body %}

--- a/loc_insurancemaps/templates/newsletter/subscription_subscribe_activated.html
+++ b/loc_insurancemaps/templates/newsletter/subscription_subscribe_activated.html
@@ -1,0 +1,11 @@
+{% extends "newsletter/common.html" %}
+
+{% load i18n %}
+
+{% block title %} {{ newsletter.title }} {{ action }} {% trans "activate" %}{% endblock title %}
+
+{% block body %}
+    <h1>{{ newsletter.title }} {{ action }} {% trans "activate" %}</h1>
+
+    <p>{% trans "Your subscription has successfully been activated." %}</p>
+{% endblock body %}

--- a/loc_insurancemaps/templates/newsletter/subscription_subscribe_email_sent.html
+++ b/loc_insurancemaps/templates/newsletter/subscription_subscribe_email_sent.html
@@ -1,0 +1,11 @@
+{% extends "newsletter/common.html" %}
+
+{% load i18n %}
+
+{% block title %}{% trans "Subscribe" %} &mdash; {{ newsletter.title }}{% endblock title %}
+
+{% block body %}
+    <h1>{% trans "Subscribe" %} &mdash; {{ newsletter.title }}</h1>
+
+    <p>{% trans "Your subscription request was successfully received and an activation email has been sent to you. In that email you will find a link which you need to follow in order to activate your subscription." %}</p>
+{% endblock body %}

--- a/loc_insurancemaps/templates/newsletter/subscription_subscribe_user.html
+++ b/loc_insurancemaps/templates/newsletter/subscription_subscribe_user.html
@@ -1,0 +1,25 @@
+{% extends "newsletter/common.html" %}
+
+{% load i18n %}
+
+{% block title %}{% trans "Subscribe" %} &mdash; {{ newsletter.title }}{% endblock title %}
+
+{% block body %}
+<h1>{% trans "Subscribe" %} &mdash; {{ newsletter.title }}</h1>
+
+<p>Welcome, {{ user }}!</p>
+
+{% if messages %}
+<ul>
+    {% for message in messages %}
+    <li>{{ message }}</li>
+    {% endfor %}
+</ul>
+{% else %}
+{% trans "Do you want to subscribe to this newsletter?" %}
+<form enctype="multipart/form-data" method="post" action="{% url "newsletter_subscribe_confirm" newsletter.slug %}">
+    {% csrf_token %}
+    <p><input id="id_submit" name="submit" value="{% trans "Subscribe" %}" type="submit" /></p>
+</form>
+{% endif %}
+{% endblock body %}

--- a/loc_insurancemaps/templates/newsletter/subscription_unsubscribe.html
+++ b/loc_insurancemaps/templates/newsletter/subscription_unsubscribe.html
@@ -1,0 +1,25 @@
+{% extends "newsletter/common.html" %}
+
+{% load i18n %}
+
+{% block title %}{% trans "Unsubscribe" %} &mdash; {{ newsletter.title }}{% endblock title %}
+
+{% block body %}
+    <h1>{% trans "Unsubscribe" %} &mdash; {{ newsletter.title }}</h1>
+
+    {% if error %}
+        <p>{% trans "Due to a technical error we were not able to submit your confirmation email. This could be because your email address is invalid." %}</p>
+
+        {% comment %} Replace the the following dummy with a valid email address and remove this comment.
+
+        <p>{% trans "If the error persists, please don't hesitate to contact us at the following email address:" %} <a href="mailto:info@foobar.com">info@foobar.com</a></p>
+
+        {% endcomment %}
+    {% else %}
+        <form enctype="multipart/form-data" method="post" action=".">
+            {% csrf_token %}
+            {{ form.as_p }}
+            <p><input id="id_submit" name="submit" value="{% trans "Unsubscribe" %}" type="submit" /></p>
+        </form>
+    {% endif %}
+{% endblock body %}

--- a/loc_insurancemaps/templates/newsletter/subscription_unsubscribe_activated.html
+++ b/loc_insurancemaps/templates/newsletter/subscription_unsubscribe_activated.html
@@ -1,0 +1,11 @@
+{% extends "newsletter/common.html" %}
+
+{% load i18n %}
+
+{% block title %} {{ newsletter.title }} {{ action }} {% trans "activate" %}{% endblock title %}
+
+{% block body %}
+    <h1>{{ newsletter.title }} {{ action }} {% trans "activate" %}</h1>
+
+    <p>{% trans "You have successfully been unsubscribed." %}</p>
+{% endblock body %}

--- a/loc_insurancemaps/templates/newsletter/subscription_unsubscribe_email_sent.html
+++ b/loc_insurancemaps/templates/newsletter/subscription_unsubscribe_email_sent.html
@@ -1,0 +1,11 @@
+{% extends "newsletter/common.html" %}
+
+{% load i18n %}
+
+{% block title %}{% trans "Unsubscribe" %} &mdash; {{ newsletter.title }}{% endblock title %}
+
+{% block body %}
+    <h1>{% trans "Unsubscribe" %} &mdash; {{ newsletter.title }}</h1>
+
+    <p>{% trans "Your unsubscription request has successfully been received. An email has been sent to you with a link you need to follow in order to confirm your unsubscription." %}</p>
+{% endblock body %}

--- a/loc_insurancemaps/templates/newsletter/subscription_unsubscribe_user.html
+++ b/loc_insurancemaps/templates/newsletter/subscription_unsubscribe_user.html
@@ -1,0 +1,27 @@
+{% extends "newsletter/common.html" %}
+
+{% load i18n %}
+
+{% block title %}{% trans "Unsubscribe" %} &mdash; {{ newsletter.title }}{% endblock title %}
+
+{% block body %}
+<h1>{% trans "Unsubscribe" %} &mdash; {{ newsletter.title }}</h1>
+
+<p>Welcome, {{ user }}!</p>
+
+{% if messages %}
+<ul>
+    {% for message in messages %}
+    <li>{{ message }}</li>
+    {% endfor %}
+</ul>
+{% else %}
+
+{% trans "Do you want to unsubscribe from this newsletter?" %}
+<form enctype="multipart/form-data" method="post" action="{% url "newsletter_unsubscribe_confirm" newsletter.slug %}">
+    {% csrf_token %}
+    <p><input id="id_submit" name="submit" value="{% trans "Unsubscribe" %}" type="submit" /></p>
+</form>
+{% endif %}
+
+{% endblock body %}

--- a/loc_insurancemaps/templates/newsletter/subscription_update.html
+++ b/loc_insurancemaps/templates/newsletter/subscription_update.html
@@ -1,0 +1,25 @@
+{% extends "newsletter/common.html" %}
+
+{% load i18n %}
+
+{% block title %}{% trans "Update" %} &mdash; {{ newsletter.title }}{% endblock title %}
+
+{% block body %}
+    <h1>{% trans "Update" %} &mdash; {{ newsletter.title }}</h1>
+
+    {% if error %}
+        <p>{% trans "Due to a technical error we were not able to submit your confirmation email. This could be because your email address is invalid." %}</p>
+
+        {% comment %} Replace the the following dummy with a valid email address and remove this comment.
+
+        <p>{% trans "If the error persists, please don't hesitate to contact us at the following email address:" %} <a href="mailto:info@foobar.com">info@foobar.com</a></p>
+
+        {% endcomment %}
+    {% else %}
+        <form enctype="multipart/form-data" method="post" action=".">
+            {% csrf_token %}
+            {{ form.as_p }}
+            <p><input id="id_submit" name="submit" value="{% trans "Update subscription" %}" type="submit" /></p>
+        </form>
+    {% endif %}
+{% endblock body %}

--- a/loc_insurancemaps/templates/newsletter/subscription_update_activated.html
+++ b/loc_insurancemaps/templates/newsletter/subscription_update_activated.html
@@ -1,0 +1,11 @@
+{% extends "newsletter/common.html" %}
+
+{% load i18n %}
+
+{% block title %}{{ newsletter.title }} {{ action }} {% trans "activate" %}{% endblock title %}
+
+{% block body %}
+    <h1>{{ newsletter.title }} {{ action }} {% trans "activate" %}</h1>
+
+    <p>{% trans "Your subscription has successfully been updated." %}</p>
+{% endblock body %}

--- a/loc_insurancemaps/templates/newsletter/subscription_update_email_sent.html
+++ b/loc_insurancemaps/templates/newsletter/subscription_update_email_sent.html
@@ -1,0 +1,11 @@
+{% extends "newsletter/common.html" %}
+
+{% load i18n %}
+
+{% block title %}{% trans "Update" %} &mdash; {{ newsletter.title }}{% endblock title %}
+
+{% block body %}
+    <h1>{% trans "Update" %} &mdash; {{ newsletter.title }}</h1>
+
+    <p>{% trans "Your update request was successfully received and an activation email has been sent to you. In that email you will find a link which you need to follow in order to update your subscription." %}</p>
+{% endblock body %}

--- a/loc_insurancemaps/templates/participants.html
+++ b/loc_insurancemaps/templates/participants.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% load django_svelte %}
+
+{% block title %}Participants{% endblock title %}
+
+{% block main_content %}
+  {% display_svelte "Participants.svelte" svelte_params %}
+{% endblock %}

--- a/loc_insurancemaps/templates/place.html
+++ b/loc_insurancemaps/templates/place.html
@@ -1,12 +1,10 @@
-{% extends 'index.html' %}
-{% load markdownify %}
+{% extends 'base.html' %}
 {% load i18n %}
-{% load base_tags %}
 {% load django_svelte %}
 
 {% block title %}{{ svelte_params.PLACE.display_name }}{% endblock title %}
 
-{% block middlefull %}
+{% block body %}
 <h1>{{ svelte_params.PLACE.display_name }}</h1>
 {% if svelte_params.PLACE.category != "State" %}
 {% for state in svelte_params.PLACE.states %}
@@ -22,8 +20,4 @@
     <p><a href="{% url 'place_view' desc.slug %}">{{ desc.display_name }}</a></p>
 {% endfor %}
 {{ place }}
-{% endblock middlefull %}
-
-{% block bigsearch %}{% endblock bigsearch %}
-{% block showcase %}{% endblock showcase %}
-{% block datasets %}{% endblock datasets %}
+{% endblock %}

--- a/loc_insurancemaps/urls.py
+++ b/loc_insurancemaps/urls.py
@@ -14,11 +14,12 @@ from .views import (
     MRMEndpointLayer,
     Viewer,
     Browse,
+    Participants,
 )
 
 urlpatterns += [
     # path('place/<str:place_slug>', PlaceView.as_view(), name='place_view'),
-    path('viewer/', RedirectView.as_view(pattern_name='browse'), name='viewer_base'),
+    path('viewer/', RedirectView.as_view(pattern_name='browse', permanent=False), name='viewer_base'),
     path('viewer/<str:place_slug>/', Viewer.as_view(), name='viewer'),
     path('browse/', Browse.as_view(), name='browse'),
     path('loc/volumes/', RedirectView.as_view(pattern_name='browse', permanent=True), name='volumes_list'),
@@ -27,6 +28,7 @@ urlpatterns += [
     path('loc/trim/<str:volumeid>/', VolumeTrim.as_view(), name="volume_trim"),
     path('mrm/', MRMEndpointList.as_view(), name="mrm_layer_list"),
     path('mrm/<str:layerid>/', MRMEndpointLayer.as_view(), name="mrm_get_resource"),
+    path('participants/', Participants.as_view(), name="participants"),
 ]
 
 if settings.ENABLE_NEWSLETTER:
@@ -45,6 +47,7 @@ urlpatterns = [
     path('help/', RedirectView.as_view(url="https://about.oldinsurancemaps.net")),
     # path('about/', RedirectView.as_view(url="https://docs.oldinsurancemaps.net")),
     path('developer/', RedirectView.as_view(url="https://about.oldinsurancemaps.net")),
+    path('people/', RedirectView.as_view(url="/participants")),
  ] + urlpatterns
 
 if settings.DEBUG:

--- a/loc_insurancemaps/views.py
+++ b/loc_insurancemaps/views.py
@@ -56,13 +56,14 @@ class HomePage(View):
         newsletter_slug = None
         user_subscribed = None
         if settings.ENABLE_NEWSLETTER:
+            newsletter = None
             if Newsletter.objects.all().exists():
                 newsletter = Newsletter.objects.all()[0]
                 newsletter_slug = newsletter.slug
-
-            user_subscription = Subscription.objects.filter(newsletter=newsletter, user=request.user)
-            if user_subscription.exists() and user_subscription[0].subscribed is True:
-                user_subscribed = True
+            if newsletter is not None and request.user.is_authenticated:
+                user_subscription = Subscription.objects.filter(newsletter=newsletter, user=request.user)
+                if user_subscription.exists() and user_subscription[0].subscribed is True:
+                    user_subscribed = True
 
         # lc = CollectionConnection(delay=0)
         # city_list = lc.get_city_list_by_state("louisiana")

--- a/loc_insurancemaps/views.py
+++ b/loc_insurancemaps/views.py
@@ -4,17 +4,21 @@ import json
 import logging
 from datetime import datetime
 
-from django.contrib.gis.geos import GEOSGeometry, Polygon
-from django.shortcuts import render, get_object_or_404
-from django.views import View
-from django.urls import reverse
-from django.http import JsonResponse, Http404, HttpResponse
-from django.middleware import csrf
 from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.contrib.gis.geos import GEOSGeometry, Polygon
+from django.http import JsonResponse, Http404, HttpResponse
+from django.shortcuts import render, get_object_or_404
+from django.urls import reverse
+from django.views import View
 from django.views.decorators.clickjacking import xframe_options_exempt
+from django.middleware import csrf
+
+from geonode.base.api.serializers import UserSerializer
 
 from georeference.utils import full_reverse
-from georeference.models.resources import Layer
+from georeference.models.sessions import SessionBase
+from georeference.models.resources import GCP, Layer
 
 from loc_insurancemaps.models import Volume, Place
 from loc_insurancemaps.utils import unsanitize_name, filter_volumes_for_use
@@ -394,6 +398,58 @@ class Viewer(View):
             request,
             "viewer.html",
             context=context_dict
+        )
+
+
+class Participants(View):
+
+    def get(self, request):
+
+        profiles = get_user_model().objects.all().exclude(username="AnonymousUser").order_by("username")
+
+        participants = []
+
+        # user the serializer from GeoNode in order to get the avatar url
+        s = UserSerializer()
+        for p in profiles:
+            p_data = s.to_representation(p)
+            psesh_ct = SessionBase.objects.filter(user=p, type="p").count()
+            gsesh_ct = SessionBase.objects.filter(user=p, type="g").count()
+            total = psesh_ct + gsesh_ct
+            volumes = Volume.objects.filter(loaded_by=p).order_by("city")
+            load_ct = volumes.count()
+            load_volumes = [
+                {
+                    "city": v.city,
+                    "year": v.year,
+                    "url": f"/loc/{v.identifier}",
+                    "volume_no": v.volume_no,
+                    "title": f"{v.city} {v.year}{' vol. ' + v.volume_no if v.volume_no else ''}"
+                } for v in volumes
+            ]
+
+            participants.append({
+                "avatar": p_data['avatar'],
+                "username": p.username,
+                "profile_url": reverse('profile_detail', args=(p.username, )),
+                "load_ct": load_ct,
+                "psesh_ct": psesh_ct,
+                "gsesh_ct": gsesh_ct,
+                "total_ct": total,
+                "volumes": load_volumes,
+                "gcp_ct": GCP.objects.filter(created_by=p).count()
+            })
+
+        context_dict = {
+            "svelte_params": {
+                "PARTICIPANTS": participants,
+            }
+        }
+
+        return render(
+            request,
+            "participants.html",
+            context=context_dict,
         )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 cogeo-mosaic==4.1
+sorl-thumbnail==12.8.0
+django-newsletter==0.9.1


### PR DESCRIPTION
Adds [django-newsletter](https://github.com/jazzband/django-newsletter) to the app, closing #42. The newsletter instance itself must be created after migrations have been run--there are no fixtures to pre-populate that content.

If a newsletter has been created, a "subscribe" box is added to the index/home page of the site. This process could be made cleaner, perhaps at a later date.

